### PR TITLE
Added build instructions for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ move into Obsidian-Qt folder
 ```
 cd Obsidian-Qt
 ```
-run buildscript to build binarys,
+run buildscript to build binaries,
 when asked for a RPC-User and a RPC-Password,
 choose a username and a secure password,
 enter them and press **Enter**
@@ -27,10 +27,10 @@ enter them and press **Enter**
 ```
 ./new-build.sh
 ```
-This generates a folder called *binarys* where the newly build binarys for
+This generates a folder called *bin* where the newly buit binaries for
 *Obsidian-Qt* and *obsidiand* can be found.
 
-#### statically linked builds
+#### Statically linked builds
 Statically linked builds are prefered when the binary should
 be executable on other GNU/Linux systems.
 To build the binaries statically, just call the *new-build.sh*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,39 @@ https://github.com/obsidianplatform/Obsidian-Qt/releases
 To build for Linux, see build.sh and src/buildquick.sh.
 For a build with static linking, look at new-build.sh.
 
+## Building Obsidian-QT
+### Ubuntu
+To install dependencys and build Obsidian-QT under Ubuntu,
+open a terminal and then do the following:
+
+```
+#clone the github repository
+git clone https://github.com/obsidianplatform/Obsidian-Qt
+
+#move into Obsidian-Qt folder
+cd Obsidian-Qt
+
+#run buildscript to build binarys
+#when asked for RPC-User and RPC-Password,
+#choose a user name and a secure password,
+#enter then and press <Enter>
+
+./new-build.sh
+
+```
+This generates a folder called **binarys** where the newly build binarys for
+**Obsidian-Qt** and **obsidiand** can be found.
+
+#### staticaly linked builds
+Staticaly linked builds are prefered when the binary should
+be runnable on different other GNU/Linux systems then Ubuntu.
+To build the binarys staticaly, just call the **new-build.sh**
+with the **--static** parameter.
+```
+./new-build.sh --static
+```
+This builds the **Obsidian-QT** as well as **obsidiand** binarys staticaly.
+
 ## License
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -12,33 +12,36 @@ For a build with static linking, look at new-build.sh.
 To install dependencys and build Obsidian-QT under Ubuntu,
 open a terminal and then do the following:
 
+
+clone the github repository
 ```
-#clone the github repository
 git clone https://github.com/obsidianplatform/Obsidian-Qt
-
-#move into Obsidian-Qt folder
+```
+move into Obsidian-Qt folder
+```
 cd Obsidian-Qt
+```
+run buildscript to build binarys,
+when asked for a RPC-User and a RPC-Password,
+choose a username and a secure password,
+enter them and press <Enter>
 
-#run buildscript to build binarys
-#when asked for RPC-User and RPC-Password,
-#choose a user name and a secure password,
-#enter then and press <Enter>
-
+```
 ./new-build.sh
 
 ```
-This generates a folder called **binarys** where the newly build binarys for
-**Obsidian-Qt** and **obsidiand** can be found.
+This generates a folder called *binarys* where the newly build binarys for
+*Obsidian-Qt* and *obsidiand* can be found.
 
 #### staticaly linked builds
 Staticaly linked builds are prefered when the binary should
 be runnable on different other GNU/Linux systems then Ubuntu.
-To build the binarys staticaly, just call the **new-build.sh**
-with the **--static** parameter.
+To build the binarys staticaly, just call the *new-build.sh*
+with the *--static* parameter.
 ```
 ./new-build.sh --static
 ```
-This builds the **Obsidian-QT** as well as **obsidiand** binarys staticaly.
+This builds the *Obsidian-QT* as well as *obsidiand* binarys staticaly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd Obsidian-Qt
 run buildscript to build binarys,
 when asked for a RPC-User and a RPC-Password,
 choose a username and a secure password,
-enter them and press <Enter>
+enter them and press **Enter**
 
 ```
 ./new-build.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://github.com/obsidianplatform/Obsidian-Qt/releases
 
 ## Building Obsidian-QT
 ### Ubuntu
-To install dependencys and build Obsidian-QT under Ubuntu,
+To install dependencies and build Obsidian-QT under Ubuntu,
 open a terminal and then do the following:
 
 
@@ -31,7 +31,7 @@ This generates a folder called *binarys* where the newly build binarys for
 *Obsidian-Qt* and *obsidiand* can be found.
 
 #### staticaly linked builds
-Staticaly linked builds are prefered when the binary should
+Statically linked builds are prefered when the binary should
 be runnable on different other GNU/Linux systems then Ubuntu.
 To build the binarys staticaly, just call the *new-build.sh*
 with the *--static* parameter.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ enter them and press **Enter**
 This generates a folder called *binarys* where the newly build binarys for
 *Obsidian-Qt* and *obsidiand* can be found.
 
-#### staticaly linked builds
+#### statically linked builds
 Statically linked builds are prefered when the binary should
 be runnable on different other GNU/Linux systems then Ubuntu.
-To build the binarys staticaly, just call the *new-build.sh*
+To build the binarys statically, just call the *new-build.sh*
 with the *--static* parameter.
 ```
 ./new-build.sh --static

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ This generates a folder called *binarys* where the newly build binarys for
 
 #### statically linked builds
 Statically linked builds are prefered when the binary should
-be runnable on different other GNU/Linux systems then Ubuntu.
-To build the binarys statically, just call the *new-build.sh*
+be executable on other GNU/Linux systems.
+To build the binaries statically, just call the *new-build.sh*
 with the *--static* parameter.
 ```
 ./new-build.sh --static
 ```
-This builds the *Obsidian-QT* as well as *obsidiand* binarys staticaly.
+This builds the *Obsidian-QT* as well as *obsidiand* binaries staticaly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Binaries for Windows, Ubuntu and MacOSX are available on the Releases tab:
 
 https://github.com/obsidianplatform/Obsidian-Qt/releases
 
-To build for Linux, see build.sh and src/buildquick.sh.
-For a build with static linking, look at new-build.sh.
 
 ## Building Obsidian-QT
 ### Ubuntu

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ enter them and press <Enter>
 
 ```
 ./new-build.sh
-
 ```
 This generates a folder called *binarys* where the newly build binarys for
 *Obsidian-Qt* and *obsidiand* can be found.

--- a/new-build.sh
+++ b/new-build.sh
@@ -12,11 +12,11 @@ cleandeps(){
 }
 
 build_cli_dyn(){
-        make -j$NPROC -f makefile.unix
+    make -j$NPROC -f makefile.unix
 }
 
 build_cli_static(){
-STATIC=1 make -j$NPROC -f makefile.unix
+    STATIC=1 make -j$NPROC -f makefile.unix
 }
 
 build_gui_static(){
@@ -84,20 +84,20 @@ install_deps(){
 install_deps
 cleandeps
 init
-mkdir binarys
+mkdir bin
 if [[ "$1" == "--static" ]]
 then
     cd src
     build_cli_static
-    mv obsidiand ../binarys
+    mv obsidiand ../bin
     cd ..
     build_gui_static
-    mv Obsidian-Qt binarys/
+    mv Obsidian-Qt bin/
 else
     cd src
     build_cli_dyn
-    mv obsidiand ../binarys
+    mv obsidiand ../bin
     cd ..
     build_gui_dyn
-    mv Obsidian-Qt binarys/
+    mv Obsidian-Qt bin/
 fi

--- a/new-build.sh
+++ b/new-build.sh
@@ -99,5 +99,5 @@ else
     mv obsidiand ../binarys
     cd ..
     build_gui_dyn
-    mv Obsidian-Oq binarys/
+    mv Obsidian-Qt binarys/
 fi


### PR DESCRIPTION
Provide more detailed instructions for building `obsidiand` for Ubuntu + other GNU/Linux systems. Describes the difference in statically linked builds.