### PR TITLE
Feature -- Add support for getblock hex

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -144,7 +144,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
         {
             Object entry;
 
-            entry.push_back(Pair("txid", tx.GetHash().GetHex()));
+            //entry.push_back(Pair("txid", tx.GetHash().GetHex()));
             TxToJSON(tx, 0, entry);
 
             txinfo.push_back(entry);
@@ -239,6 +239,10 @@ Value getblock(const Array& params, bool fHelp)
     std::string strHash = params[0].get_str();
     uint256 hash(strHash);
 
+    bool fVerbose = true;
+    if (params.size() > 1)
+      fVerbose = params[1].get_bool();
+
     if (mapBlockIndex.count(hash) == 0)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
@@ -246,12 +250,14 @@ Value getblock(const Array& params, bool fHelp)
     CBlockIndex* pblockindex = mapBlockIndex[hash];
     block.ReadFromDisk(pblockindex, true);
 
-    CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
-    ssBlock << block;
-    std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
-    return strHex;
+    if (!fVerbose) {
+      CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+      ssBlock << block;
+      std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+      return strHex;
+    }
 
-    //return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
+    return blockToJSON(block, pblockindex, fVerbose);
 }
 
 Value getblockbynumber(const Array& params, bool fHelp)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -246,7 +246,12 @@ Value getblock(const Array& params, bool fHelp)
     CBlockIndex* pblockindex = mapBlockIndex[hash];
     block.ReadFromDisk(pblockindex, true);
 
-    return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
+    CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
+    ssBlock << block;
+    std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+    return strHex;
+
+    //return blockToJSON(block, pblockindex, params.size() > 1 ? params[1].get_bool() : false);
 }
 
 Value getblockbynumber(const Array& params, bool fHelp)

--- a/src/rpcprotocol.cpp
+++ b/src/rpcprotocol.cpp
@@ -252,3 +252,11 @@ Object JSONRPCError(int code, const string& message)
     error.push_back(Pair("message", message));
     return error;
 }
+
+int RPCSerializationFlags()
+{
+    int flag = 0;
+    if (GetArg("-rpcserialversion", DEFAULT_RPC_SERIALIZE_VERSION) == 0)
+        flag |= SERIALIZE_TRANSACTION_NO_WITNESS;
+    return flag;
+}

--- a/src/rpcprotocol.h
+++ b/src/rpcprotocol.h
@@ -137,4 +137,10 @@ json_spirit::Object JSONRPCReplyObj(const json_spirit::Value& result, const json
 std::string JSONRPCReply(const json_spirit::Value& result, const json_spirit::Value& error, const json_spirit::Value& id);
 json_spirit::Object JSONRPCError(int code, const std::string& message);
 
+static const int DEFAULT_RPC_SERIALIZE_VERSION = 1;
+static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
+
+// Retrieves any serialization flags requested in command line argument
+int RPCSerializationFlags();
+
 #endif


### PR DESCRIPTION
Obsidian is currently missing a feature supported by most blockchains where calling `getblock _blockhash_` returns just the `HEX` code for the specific block. This feature allows both the raw `HEX` code to be returned by `getblock` as well as the verbose block information by passing `true` as an additional parameter.

By default, `getblock` will return verbosely. To fetch the raw hex code of the block you must specifically pass `false`.


### Current Example
```
root@NODE:~/Obsidian-Qt# ./src/obsidiand getblock ad4521e6fe8376491f46fcc69216441eb85254428673e2abef9ab2fa55405d36

{
    "hash" : "ad4521e6fe8376491f46fcc69216441eb85254428673e2abef9ab2fa55405d36",
    "confirmations" : 89188,
    "size" : 445,
    "height" : 542300,
    "version" : 7,
    "merkleroot" : "52c590bb9cee38c390cec13c7e671f0f08e03c78e209ff20935cb81a2d3123bc",
    "mint" : 20.00000000,
    "time" : 1539857072,
    "nonce" : 0,
    "bits" : "1a031d96",
    "difficulty" : 5384876.48548844,
    "blocktrust" : "522afea7479fa6",
    "chaintrust" : "298966663c3fd693df0",
    "previousblockhash" : "8a517e6351788b3ed58e4d8bf26534c5a0957deb939aa6e20ad65e59bd76a800",
    "nextblockhash" : "ca9595043f7ebe20e8d9c1bfe6975f302115094709de44ef7d358a1eb69b4130",
    "flags" : "proof-of-stake",
    "proofhash" : "000052785bde0627494b4e9e19702d05e90607f2b642ea5a34641d8adeffdd15",
    "entropybit" : 0,
    "modifier" : "a48554e051406524",
    "modifierv2" : "84ed877087b3619a9171807fb1198881f4f4d0428740c77f366c1af2f6496dc6",
    "tx" : [
        "cd280030628efaf3bf0468d908fe9be3a3c2fd527846ce719c2edca3cfb6021c",
        "5785c68283615eaa7b3212d9f2ac5dc7248aa01778ff3d7c73ebf20c3809b31c"
    ],
    "signature" : "3045022100fa06fe1e35ddc83dd5ad67c0c1bdae6f5004c9784c17dcf7a742b31d2a492b470220335ab448384cb024179d54ef8dc820f544a0f00ba580278e0751bc5ec5d80208"
}
```


### Updated Example:
```
root@NODE:~/Obsidian-Qt# ./src/obsidiand getblock ad4521e6fe8376491f46fcc69216441eb85254428673e2abef9ab2fa55405d36 false

0700000000a876bd595ed60ae2a69a93eb7d95a0c53465f28b4d8ed53e8b7851637e518abc23312d1ab85c9320ff09e2783ce0080f1f677e3cc1ce90c338ee9cbb90c552b05ac85b961d031a000000000201000000b05ac85b010000000000000000000000000000000000000000000000000000000000000000ffffffff04035c4608ffffffff010000000000000000000000000001000000b05ac85b01185a7fe575c0afa4c672102da15654069135f647677ed710df1041b3aa105eec010000004847304402203994ace590acd63fe1362340da8de6d8a025387e5ee0a05e72886e946d03cf3b02205cb5a3a7a15c2f24e3da4ed7ed75facff4555947271a143e4357c2207c9c1e8301ffffffff030000000000000000000008beed14000000232103c5cdddbdcff4b61d5534d50e6fd76ece789325e0d8636d23077db77cd3fa30fcac404acded14000000232103c5cdddbdcff4b61d5534d50e6fd76ece789325e0d8636d23077db77cd3fa30fcac00000000473045022100fa06fe1e35ddc83dd5ad67c0c1bdae6f5004c9784c17dcf7a742b31d2a492b470220335ab448384cb024179d54ef8dc820f544a0f00ba580278e0751bc5ec5d80208
```